### PR TITLE
PS-2266 Include symfony.lock during initial composer install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN pecl channel-update pecl.php.net \
     && yes | pecl install xdebug-2.9.8 \
     && docker-php-ext-enable xdebug
 
-COPY composer.* ./
+COPY composer.* symfony.lock ./
 RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
+
 COPY . .
 RUN composer install $COMPOSER_FLAGS


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-2266

Since Composer 2.1.2, Symfony Flex is run even with `--no-scripts` options